### PR TITLE
do not read dbufs. It eats too much CPU in arcstat.pl

### DIFF
--- a/lib/Sun/Solaris/Kstat.pm
+++ b/lib/Sun/Solaris/Kstat.pm
@@ -55,7 +55,7 @@ sub update {
     my @files = readdir(MODDIR);
     my $file;
     foreach $file (@files) {
-      if ($file eq "." || $file eq "..") {
+      if ($file eq "." || $file eq ".." || $file eq "dbufs") {
         next;
       }
 


### PR DESCRIPTION
In the current ZoL versions dbufs spits out too much information that kills the Perl parser
